### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/source/pages/oss-licenses/oss-licenses.js
+++ b/source/pages/oss-licenses/oss-licenses.js
@@ -40,7 +40,17 @@ Page({
             version: this.data.licensesBuild[index].version,
             licenseBody: this.data.licensesBuild[index].licenseText,
             repoLink: this.data.licensesBuild[index].repository,
-            repoType: this.data.licensesBuild[index].repository.toLowerCase().includes("github.com") ? "GitHub" : (this.data.licensesBuild[index].repository.toLowerCase().includes("gitlab.com") ? "GitLab" : "Unknown")
+            repoType: (() => {
+                try {
+                    const url = new URL(this.data.licensesBuild[index].repository);
+                    const host = url.host.toLowerCase();
+                    if (host === "github.com") return "GitHub";
+                    if (host === "gitlab.com") return "GitLab";
+                } catch (e) {
+                    console.error("Invalid URL:", e);
+                }
+                return "Unknown";
+            })()
         })
     }, onUnload() {
         this.storeBindings.destroyStoreBindings();


### PR DESCRIPTION
Potential fix for [https://github.com/ArcticFoxPro/QQVersionListTool-WeChatMiniProgram/security/code-scanning/8](https://github.com/ArcticFoxPro/QQVersionListTool-WeChatMiniProgram/security/code-scanning/8)

To fix the problem, we need to parse the URL and check the host component explicitly rather than using a substring check. This ensures that the host is correctly identified and validated against a whitelist of allowed hosts.

1. Parse the URL to extract the host component.
2. Check if the host matches "github.com" or "gitlab.com".
3. Update the `repoType` assignment to use the parsed host for validation.

We will use the `URL` constructor available in modern JavaScript to parse the URL and extract the host component.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
