### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL substring sanitization

### DIFF
--- a/source/pages/oss-licenses/oss-licenses.js
+++ b/source/pages/oss-licenses/oss-licenses.js
@@ -40,7 +40,17 @@ Page({
             version: this.data.licensesBuild[index].version,
             licenseBody: this.data.licensesBuild[index].licenseText,
             repoLink: this.data.licensesBuild[index].repository,
-            repoType: this.data.licensesBuild[index].repository.toLowerCase().includes("github.com") ? "GitHub" : (this.data.licensesBuild[index].repository.toLowerCase().includes("gitlab.com") ? "GitLab" : "Unknown")
+            repoType: (() => {
+                try {
+                    const url = new URL(this.data.licensesBuild[index].repository);
+                    const host = url.host.toLowerCase();
+                    if (host === "github.com") return "GitHub";
+                    if (host === "gitlab.com") return "GitLab";
+                } catch (e) {
+                    console.error("Invalid URL:", e);
+                }
+                return "Unknown";
+            })()
         })
     }, onUnload() {
         this.storeBindings.destroyStoreBindings();


### PR DESCRIPTION
Potential fix for [https://github.com/ArcticFoxPro/QQVersionListTool-WeChatMiniProgram/security/code-scanning/9](https://github.com/ArcticFoxPro/QQVersionListTool-WeChatMiniProgram/security/code-scanning/9)

To fix the problem, we need to parse the repository URL and check its host value explicitly. This ensures that the host is correctly identified and prevents any malicious URLs from being miscategorized. We will use the `URL` class available in modern JavaScript to parse the URL and extract the host.

1. Import the `URL` class if necessary.
2. Parse the repository URL using the `URL` class.
3. Check the host value against the allowed hosts ("github.com" and "gitlab.com").
4. Update the `repoType` based on the parsed host value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
